### PR TITLE
Proper use of `QueryString`.

### DIFF
--- a/BFF/src/Host/Internal/StrictSameSiteExternalAuthenticationMiddleware.cs
+++ b/BFF/src/Host/Internal/StrictSameSiteExternalAuthenticationMiddleware.cs
@@ -35,7 +35,7 @@ namespace IdentityModel.AspNetCore
                     }
                     else if (ctx.Request.Method == "GET" && !ctx.Request.Query["skip"].Any())
                     {
-                        location = ctx.Request.Path + ctx.Request.QueryString + "&skip=1";
+                        location = ctx.Request.Path + ctx.Request.QueryString.Add("skip", "1");
                     }
 
                     if (location != null)


### PR DESCRIPTION
If `QueryString` is empty, then `PathString + QueryString + "&skip=1"`  becomes `"/target/path&skip=1"`.
If you instead do `PathString + QueryString.Add("skip", "1")`, it becomes `"/target/path?skip=1"`.